### PR TITLE
filtering products over a selected priced functional

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -273,6 +274,13 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if min_price is not None:
+            try:
+                min_price = float(min_price)
+                products = products.filter(price__gte=min_price)
+            except ValueError:
+                  return Response({"message": "min_price must be a number"}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

Inside the `list()` method of `ProductViewSet`, filtering products by a minimum price was added using the `min_price` query parameter.  Using `.filter(price__gte=...)` tells Django to include only products priced greater than or equal to that value. The `float()` function is a built-in function that converts a value to a floating-point number or in simpler terms, a decimal number.

## Requests / Responses

**Request**
Run the backend server and navigate to http://localhost:8000/products?min_price=150 
**Response**
GET `/products?min_price=150` Retrieves products with a price greater than or equal to 150.

## Testing

1. Run the server: `python manage.py runserver`
2. Navigate to: `http://localhost:8000/products?min_price=150`
3. Confirm the response only includes products with a price **≥ 150**
4. Test with other values like `?min_price=50` to verify filtering works


## Related Issues
- Closes #19 