### PR TITLE
Ft/like disklike products 22

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -68,6 +68,8 @@ class Product(SafeDeleteModel):
         avg = total_rating / count
         return avg
 
+    # TODO: liked property
+
     class Meta:
         verbose_name = ("product")
         verbose_name_plural = ("products")

--- a/bangazonapi/models/productlike.py
+++ b/bangazonapi/models/productlike.py
@@ -1,0 +1,14 @@
+from django.db import models
+from .product import Product
+from .customer import Customer
+
+
+class ProductLike(models.Model):
+    customer = models.ForeignKey(
+        Customer, on_delete=models.CASCADE, related_name="likes")
+    product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name="likes"
+                                )
+
+    class Meta:
+        # We don't want a customer to be able to like the same product multiple times. unique_together prevents duplicate rows in a table based on a combination of fields.
+        unique_together = ['customer', 'product']

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -19,7 +19,7 @@ class ProductSerializer(serializers.ModelSerializer):
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
                   'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                  'average_rating', 'can_be_rated', 'is_liked')
         depth = 1
 
 
@@ -94,13 +94,15 @@ class Products(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         new_product.customer = customer
 
-        product_category = ProductCategory.objects.get(pk=request.data["category_id"])
+        product_category = ProductCategory.objects.get(
+            pk=request.data["category_id"])
         new_product.category = product_category
 
         if "image_path" in request.data:
             format, imgstr = request.data["image_path"].split(';base64,')
             ext = format.split('/')[-1]
-            data = ContentFile(base64.b64decode(imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
+            data = ContentFile(base64.b64decode(
+                imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
 
             new_product.image_path = data
 
@@ -152,7 +154,10 @@ class Products(ViewSet):
         """
         try:
             product = Product.objects.get(pk=pk)
-            serializer = ProductSerializer(product, context={'request': request})
+            # TODO: add is_liked here
+
+            serializer = ProductSerializer(
+                product, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
@@ -182,7 +187,8 @@ class Products(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         product.customer = customer
 
-        product_category = ProductCategory.objects.get(pk=request.data["category_id"])
+        product_category = ProductCategory.objects.get(
+            pk=request.data["category_id"])
         product.category = product_category
         product.save()
 
@@ -274,6 +280,8 @@ class Products(ViewSet):
 
             products = filter(sold_filter, products)
 
+        # TODO: add is_liked . loop over them to annotate is_liked for each one
+
         serializer = ProductSerializer(
             products, many=True, context={'request': request})
         return Response(serializer.data)
@@ -285,7 +293,8 @@ class Products(ViewSet):
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)
-            rec.customer = Customer.objects.get(user__id=request.data["recipient"])
+            rec.customer = Customer.objects.get(
+                user__id=request.data["recipient"])
             rec.product = Product.objects.get(pk=pk)
 
             rec.save()
@@ -293,3 +302,7 @@ class Products(ViewSet):
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    # TODO: custom action: like
+
+    # TODO: custom action: unlike


### PR DESCRIPTION
Users can like and unlike products.

## Changes

1. Made a join table between product and customer called ProductLike. The related name for both product and customer is “likes.” Added a meta class to the model with a field unique_together which prevents duplicate likes to the same product by the same user.
2. Added custom property “is_liked” on product model so that we can write product.is_liked (in our list and retrieve methods in product view set, see step 4) /access it as if it’s a normal field. 
    
    **That name (is_liked) corresponds with how front end has it set up to access the property (ternary in components/product/detail.js). 
    
3. Added “is_liked” to product serializer so that it is included in the property in the API response (when product.is_liked is set) JSON so FE can use it.
4. Set is_liked to true/false in retrieve and list methods in Product view by checking if a row for the current product and customer exist in the ProductLike join table.
5. Made custom actions to like and unlike products. The action decorator auto generates the route used and allows for tying it to a specific product. I looked at this to help me remember how custom actions work: https://github.com/nashville-software-school/server-side-python-curriculum/blob/evening-cohorts/book-3-levelup/chapters/LU_CUSTOM_ACTION.md

## Requests / Responses

1. 
**Request**

/products/:pk/like

**Response**

```json
{
 "message": "Product liked"
}
```

HTTP/1.1 201 OK

**Response**

2.

**Request**

/products/:pk:unlike

**Response**

```json
{}
```

HTTP/1.1 204 NO CONTENT

## Testing

- makemigrations and migrate
- Like and unlike a product on its product page

## Related Issues

- closes [#22](https://github.com/Evening-Cohort-29/Bangazon-client-mgitwk/issues/22)