### PR TITLE
products/liked endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,7 @@
         "--django-settings-module=bangazon.settings",
         "--max-line-length=120"
     ],
+    "python-envs.defaultEnvManager": "ms-python.python:poetry",
+    "python-envs.defaultPackageManager": "ms-python.python:poetry",
+    "python-envs.pythonProjects": [],
 }

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Product, Customer, ProductCategory, ProductLike
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
 from rest_framework.parsers import MultiPartParser, FormParser
 
 
@@ -349,3 +349,17 @@ class Products(ViewSet):
             return Response(status=status.HTTP_204_NO_CONTENT)
         except ProductLike.DoesNotExist:
             return Response({"message": "Product not liked yet"}, status=status.HTTP_404_NOT_FOUND)
+
+    #  GET /products/liked
+    @action(methods=["get"], detail=False, url_path='liked', permission_classes=[IsAuthenticated])
+    def liked(self, request):
+        """Get list of liked products by user"""
+        customer = Customer.objects.get(user=request.user)
+        # get the ProductLike objs for the customer
+        likes = ProductLike.objects.filter(customer=customer)
+        # get the product for each
+        products = [like.product for like in likes]
+
+        serializer = ProductSerializer(
+            products, many=True, context={'request': request})
+        return Response(serializer.data)


### PR DESCRIPTION
## Description

- Added a new 'liked' action in the Product view to allow users to retrieve a list of products they have liked. This includes filtering ProductLike objects by the current user and serializing the associated products.

## Files Changed
- [bangazonapi/views/product.py](https://github.com/Evening-Cohort-29/Bangazon-api-mgitwk/pull/26/files#r2249327716): Added a new liked custom action that allows users to retrieve a list of products they have liked.


## Testing

Description of how to test code...

- [ ] Run migrations if you haven't already
- [ ] Follow remaining testing steps in upcoming FE PR

## Related Issues
[#22](https://github.com/Evening-Cohort-29/Bangazon-client-mgitwk/issues/22)